### PR TITLE
Added missing error message when payment failed

### DIFF
--- a/enrol.php
+++ b/enrol.php
@@ -199,6 +199,7 @@ if ($costvalue == 000) {  ?>
           ).then(function(result) {
             if (result.error) {
               // Display error.message in your UI.
+               $("#transaction-status").html("<center> Sorry! Your transaction is failed: " + result.error.code + "</center>");  
             } else {
               // The setup has succeeded. Display a success message.
               var result = Object.keys(result).map(function(key) {


### PR DESCRIPTION
Any warning was been displayed when an error like Card declined or other error happened. There was not feedback in the UI, the message "Your transaction is processing..." remained even when the error was received